### PR TITLE
Remove temporary SSH keys created by packer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ bin/*
 
 # Chefspec
 /.coverage/
+
+# Vim swap and temp files
+*.swp
+*~

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -2,8 +2,8 @@
 driver_config:
   aws_access_key_id: <%= ENV['AWS_ACCESS_KEY'] %>
   aws_secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>
-  aws_ssh_key_id: eu-west-1
-  
+  aws_ssh_key_id: <%= ENV['AWS_REGION'] %>
+
 provisioner:
   name: chef_zero
   require_chef_omnibus: latest
@@ -14,11 +14,11 @@ platforms:
   driver_plugin: ec2
   driver_config:
     image_id: ami-ee2aa59d
-    region: eu-west-1
-    availability_zone: eu-west-1a
+    region: <%= ENV['AWS_REGION'] %>
+    availability_zone: <%= ENV['AWS_REGION'] %>a
     instance_type: t2.micro
     iam_profile_name: gocdAgent
- 
+
 suites:
 - name: default
   run_list:

--- a/packer.sh
+++ b/packer.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+export AWS_REGION=us-east-1
+
 ## Obtain the source AMI to use for our Packer build.
 ## ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406
-base_ami_id='ami-6077f713'
+base_ami_id=$(aws ec2 describe-images \
+    --filters Name=name,Values="ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406" \
+    --region $AWS_REGION \
+    --output text \
+    --query "Images[*].ImageId" \
+)
+
+echo $base_ami_id
 
 ## Build an AMI for this cookbook
 $(which chef) exec rake packer[$base_ami_id]

--- a/packer.sh
+++ b/packer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export AWS_REGION=us-east-1
+export AWS_REGION=eu-west-1
 
 ## Obtain the source AMI to use for our Packer build.
 ## ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406

--- a/template.json
+++ b/template.json
@@ -3,7 +3,7 @@
     "version":           "{{env `VERSION`}}",
     "aws_access_key":    "{{env `AWS_ACCESS_KEY`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_KEY`}}",
-    "name":              "linux-ubuntu-base",
+    "name":              "base-ubuntu-16.04",
     "region":            "{{env `AWS_REGION`}}",
     "source_ami":        "ami-9abea4fb",
     "instance_type":     "t2.micro",
@@ -23,10 +23,10 @@
       "ssh_username":    "ubuntu",
       "ssh_private_ip":  "false",
       "user_data_file":  "{{user `user_data_file`}}",
-      "ami_name":        "{{user `name`}} {{timestamp}}",
+      "ami_name":        "{{user `name`}}-{{timestamp}}",
       "ami_description": "{{user `name`}} AMI",
       "run_tags": { "ami-create": "{{user `name`}}" },
-      "tags": { "name": "{{user `name`}}", "created": "{{timestamp}}" },
+      "tags": { "Name": "{{user `name`}}", "Created": "{{timestamp}}" },
       "associate_public_ip_address": true
     }
   ],

--- a/template.json
+++ b/template.json
@@ -57,6 +57,12 @@
       "cookbook_paths":      ["./berks-cookbooks"],
       "run_list":           ["core-linux::default"],
       "staging_directory":  "/cookbooks"
+    },
+    {
+      "type":   "shell",
+      "inline": [
+          "rm /home/ubuntu/.ssh/authorized_keys"
+      ]
     }
   ]
 }

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
     "aws_access_key":    "{{env `AWS_ACCESS_KEY`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_KEY`}}",
     "name":              "linux-ubuntu-base",
-    "region":            "eu-west-1",
+    "region":            "{{env `AWS_REGION`}}",
     "source_ami":        "ami-9abea4fb",
     "instance_type":     "t2.micro",
     "ssh_username":      "ubuntu",


### PR DESCRIPTION
Updated: this also uses the new naming convention for the base Linux box.