### PR TITLE
Use Ubuntu 16.04 instead of 14.04 for the base AMI

### DIFF
--- a/packer.sh
+++ b/packer.sh
@@ -2,14 +2,15 @@
 
 export AWS_REGION=eu-west-1
 
-## Obtain the source AMI to use for our Packer build.
-## ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406
-base_ami_id=$(aws ec2 describe-images \
-    --filters Name=name,Values="ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406" \
-    --region $AWS_REGION \
-    --output text \
-    --query "Images[*].ImageId" \
-)
+# Obtain the source AMI to use for our Packer build.
+# ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406
+# base_ami_id=$(aws ec2 describe-images \
+#     --filters Name=name,Values="ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160406" \
+#     --region $AWS_REGION \
+#     --output text \
+#     --query "Images[*].ImageId" \
+# )
+base_ami_id=ami-6f587e1c
 
 echo $base_ami_id
 


### PR DESCRIPTION
Uses hard coded AMI. I've left the search code in, commented out, in case anyone wants to revert to using that method of doing things in the future.